### PR TITLE
Fix lua error in dragndrop.StopDragging by handling nil value case

### DIFF
--- a/lua/autorun/favorites.lua
+++ b/lua/autorun/favorites.lua
@@ -172,7 +172,9 @@ Load(g_file) -- Load favorites/favorites.json.
 if CLIENT then -- This is madness.
 	local originalStopDragging = dragndrop.StopDragging
 	dragndrop.StopDragging = function()
-		local src = dragndrop.GetDroppable()[1]
+		local srctable = dragndrop.GetDroppable()
+        	if !srctable or !srctable[1] then return originalStopDragging() end 
+        	local src = srctable[1]
 		local dst = vgui.GetHoveredPanel()
 		if dst == nil then return end
 		local panelName = dst:GetName()


### PR DESCRIPTION
Current lua error:
[Favourites] lua/autorun/favorites.lua:175: attempt to index a nil value
  1. StopDragging - lua/autotun/favorites.lua:175 
    2. unknown - lua/includes/extensions/client/panel/dragdop.lua:51

Error is thrown when moving a drag n drop panel with right click. I'm guessing that when StopDragging is called from right click menu the panels have already been removed from GetDroppable causing the nil value error

The fix just ensures that the table returned from GetDroppable is not nil and has a value at key [1]